### PR TITLE
style: :heavy_minus_sign: removes `"@storybook/addon-controls"` from …

### DIFF
--- a/packages/ui/.storybook/main.js
+++ b/packages/ui/.storybook/main.js
@@ -4,6 +4,5 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/preset-create-react-app",
-    "@storybook/addon-controls",
   ],
 };


### PR DESCRIPTION
…main.js

Should have been removed in the previous commit. I am blind and I have to pay more attention.